### PR TITLE
Making sure providing Testee client config does not cause an error

### DIFF
--- a/steal-mocha.js
+++ b/steal-mocha.js
@@ -18,8 +18,8 @@ define(["mocha/mocha", "@loader", "mocha/mocha.css!"], function(mocha, System){
 	}
 
 	steal.done().then(function() {
-		if (window.Testee) {
-			Testee.init();
+		if (window.Testee && window.Testee.init) {
+			window.Testee.init();
 		}
 
 		return getOpts;

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
+<script>window.Testee = { provider: { type: 'rest' } };</script>
 <script src="../node_modules/steal/steal.js"
   data-mocha="bdd"
   data-mocha-require="test/setup"


### PR DESCRIPTION
If you provide configuration to testee via `window.Testee` but you're not actually running your tests via Testee, `steal-mocha` will attempt to run `Testee.init`.

This PR checks if `window.Testee.init` exists before invoking it.
